### PR TITLE
:zap: repository test의 spring context가 재사용 가능하게 조정

### DIFF
--- a/module-sample/repository-jdbc/src/integrationTest/kotlin/team/flex/module/sample/corehr/TestApplication.kt
+++ b/module-sample/repository-jdbc/src/integrationTest/kotlin/team/flex/module/sample/corehr/TestApplication.kt
@@ -6,8 +6,17 @@ package team.flex.module.sample.corehr
 
 import org.springframework.boot.SpringBootConfiguration
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.context.annotation.Import
+import team.flex.module.sample.corehr.company.department.repository.DepartmentRepositoryAutoConfiguration
+import team.flex.module.sample.corehr.company.repository.CompanyRepositoryAutoConfiguration
+import team.flex.module.sample.corehr.employee.repository.EmployeeRepositoryAutoConfiguration
 import java.util.TimeZone
 
+@Import(
+    EmployeeRepositoryAutoConfiguration::class,
+    CompanyRepositoryAutoConfiguration::class,
+    DepartmentRepositoryAutoConfiguration::class,
+)
 @EnableAutoConfiguration
 @SpringBootConfiguration
 class TestApplication {

--- a/module-sample/repository-jdbc/src/integrationTest/kotlin/team/flex/module/sample/corehr/company/CompanyRepositoryIntegrationTest.kt
+++ b/module-sample/repository-jdbc/src/integrationTest/kotlin/team/flex/module/sample/corehr/company/CompanyRepositoryIntegrationTest.kt
@@ -8,18 +8,13 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
-import org.springframework.context.annotation.Import
 import org.springframework.test.context.TestConstructor
 import team.flex.module.sample.corehr.company.repository.CompanyEntity
 import team.flex.module.sample.corehr.company.repository.CompanyJdbcRepository
 import team.flex.module.sample.corehr.company.repository.CompanyRepository
-import team.flex.module.sample.corehr.company.repository.CompanyRepositoryAutoConfiguration
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
-@Import(
-    CompanyRepositoryAutoConfiguration::class,
-)
 @DataJdbcTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)

--- a/module-sample/repository-jdbc/src/integrationTest/kotlin/team/flex/module/sample/corehr/company/department/DepartmentRepositoryIntegrationTest.kt
+++ b/module-sample/repository-jdbc/src/integrationTest/kotlin/team/flex/module/sample/corehr/company/department/DepartmentRepositoryIntegrationTest.kt
@@ -8,20 +8,15 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
-import org.springframework.context.annotation.Import
 import org.springframework.test.context.TestConstructor
 import team.flex.module.sample.corehr.company.CompanyIdentity
 import team.flex.module.sample.corehr.company.department.repository.DepartmentEntity
 import team.flex.module.sample.corehr.company.department.repository.DepartmentJdbcRepository
 import team.flex.module.sample.corehr.company.department.repository.DepartmentRepository
-import team.flex.module.sample.corehr.company.department.repository.DepartmentRepositoryAutoConfiguration
 import team.flex.module.sample.corehr.company.of
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
-@Import(
-    DepartmentRepositoryAutoConfiguration::class,
-)
 @DataJdbcTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)

--- a/module-sample/repository-jdbc/src/integrationTest/kotlin/team/flex/module/sample/corehr/employee/EmployeeRepositoryIntegrationTest.kt
+++ b/module-sample/repository-jdbc/src/integrationTest/kotlin/team/flex/module/sample/corehr/employee/EmployeeRepositoryIntegrationTest.kt
@@ -8,20 +8,15 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
-import org.springframework.context.annotation.Import
 import org.springframework.test.context.TestConstructor
 import team.flex.module.sample.corehr.company.CompanyIdentity
 import team.flex.module.sample.corehr.company.of
 import team.flex.module.sample.corehr.employee.repository.EmployeeEntity
 import team.flex.module.sample.corehr.employee.repository.EmployeeJdbcRepository
 import team.flex.module.sample.corehr.employee.repository.EmployeeRepository
-import team.flex.module.sample.corehr.employee.repository.EmployeeRepositoryAutoConfiguration
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
-@Import(
-    EmployeeRepositoryAutoConfiguration::class,
-)
 @DataJdbcTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)


### PR DESCRIPTION
https://discord.com/channels/1377214678945759252/1379308940256346122/1379314524804354091

디스코드 커뮤니티에서 김대겸님이 주신 개선 의견을 수렴하여 반영합니다